### PR TITLE
fix: copy migrations directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY Cargo.toml Cargo.lock ./
 # Copy source code
 COPY src ./src
 COPY data ./data
+COPY migrations ./migrations
 
 # Build release binary
 RUN cargo build --release


### PR DESCRIPTION
## Summary
- Add `COPY migrations ./migrations` to Dockerfile so `sqlx::migrate!` macro can embed migrations at compile time

## Problem
The `sqlx::migrate!("./migrations")` macro runs at **compile time** and needs the migrations directory to exist during the Docker build. Without it, the build fails with:

```
error: error canonicalizing migration directory /app/./migrations: No such file or directory
```

## Test plan
- [ ] CI tests pass
- [ ] Deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure migrations are available during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->