### PR TITLE
fix: address PR review feedback for multi-language support

### DIFF
--- a/.claude/commands/pr-unresolved.md
+++ b/.claude/commands/pr-unresolved.md
@@ -98,7 +98,16 @@ After the user confirms which comments to fix and you've completed the work:
        -f content="-1" -X POST
      ```
 
-3. **Resolve threads** using the GraphQL API (for comments that were addressed):
+3. **Reply with a meaningful message to the thread**:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+     -f body="Fixed! <brief description of what was done>" \
+     -F in_reply_to={comment_id} \
+     -X POST
+   ```
+   Note: The comment ID can be obtained from the initial GraphQL query (the `id` field in `comments.nodes`).
+
+4. **Resolve threads** using the GraphQL API (for both fixed and skipped comments):
    ```bash
    gh api graphql -f query='
    mutation {
@@ -107,12 +116,6 @@ After the user confirms which comments to fix and you've completed the work:
      }
    }'
    ```
-   Note: The thread node ID can be obtained from the initial GraphQL query (the `id` field in `reviewThreads.nodes`).
-
-4. **Leave threads unresolved** if:
-   - The comment was intentionally skipped with a justification
-   - The issue needs further discussion
-   - You're waiting for the reviewer to verify the fix
 
 ## Example Output
 


### PR DESCRIPTION
- Update CLAUDE.md to document multi-language support features including localized headers, translation module, and caching
- Fix translate_summary() to return error on empty OpenAI choices instead of silently returning original summary
- Update test and docstring to match new error handling behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-language support for summaries in English and Spanish.
  * Introduced localized message headers and enhanced formatting for Telegram delivery.
  * Implemented subscriber language preferences for personalized content.

* **Documentation**
  * Updated PR thread handling workflow with improved interaction sequence.

* **Improvements**
  * Enhanced error handling for translation failures with English fallback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->