### PR TITLE
refactor: implement centralized i18n infrastructure (Phase 1-2)

### DIFF
--- a/migrations/20260119000001_flexible_language_codes.down.sql
+++ b/migrations/20260119000001_flexible_language_codes.down.sql
@@ -1,0 +1,11 @@
+-- Rollback: Restore hardcoded language constraint
+
+-- Remove flexible format constraint
+ALTER TABLE subscribers DROP CONSTRAINT IF EXISTS valid_language_code_format;
+
+-- Restore original hardcoded constraint (en, es only)
+ALTER TABLE subscribers ADD CONSTRAINT valid_language_code
+CHECK (language_code IN ('en', 'es'));
+
+-- Remove comment
+COMMENT ON COLUMN subscribers.language_code IS NULL;

--- a/migrations/20260119000001_flexible_language_codes.sql
+++ b/migrations/20260119000001_flexible_language_codes.sql
@@ -1,0 +1,22 @@
+-- Remove hardcoded language constraint to allow extensibility
+ALTER TABLE subscribers DROP CONSTRAINT IF EXISTS valid_language_code;
+
+-- Add flexible format constraint (2-5 lowercase letters for ISO 639-1/639-3 codes)
+ALTER TABLE subscribers ADD CONSTRAINT valid_language_code_format
+CHECK (language_code ~ '^[a-z]{2,5}$');
+
+-- Add comment explaining the format
+COMMENT ON COLUMN subscribers.language_code IS
+'ISO 639-1/639-3 language code (e.g., en, es, fr, pt, de). Must be 2-5 lowercase letters. Supported codes are defined in the application registry.';
+
+-- Verify existing data still valid (should only have 'en' and 'es')
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM subscribers
+        WHERE language_code !~ '^[a-z]{2,5}$'
+    ) THEN
+        RAISE EXCEPTION 'Invalid language codes found in subscribers table';
+    END IF;
+END
+$$;

--- a/src/i18n/language.rs
+++ b/src/i18n/language.rs
@@ -1,0 +1,265 @@
+//! Language type: Flexible, validated language representation.
+//!
+//! This module provides the `Language` type, which replaces the hardcoded
+//! `Language` enum with a flexible struct that validates against the registry.
+
+use crate::i18n::{LanguageConfig, LanguageRegistry};
+use anyhow::{bail, Result};
+
+/// A validated language.
+///
+/// This type represents a language that has been validated against the registry.
+/// It ensures that only supported, enabled languages can be constructed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Language {
+    /// ISO 639-1 language code (e.g., "en", "es")
+    code: &'static str,
+}
+
+impl Language {
+    /// Backward compatibility constant for English.
+    ///
+    /// This allows existing code using `Language::English` to continue working
+    /// without changes by using `Language::ENGLISH` instead.
+    pub const ENGLISH: Language = Language { code: "en" };
+
+    /// Backward compatibility constant for Spanish.
+    ///
+    /// This allows existing code using `Language::Spanish` to continue working
+    /// without changes by using `Language::SPANISH` instead.
+    pub const SPANISH: Language = Language { code: "es" };
+
+    /// Create a Language from a language code string.
+    ///
+    /// # Arguments
+    /// * `code` - The ISO 639-1 language code (e.g., "en", "es")
+    ///
+    /// # Returns
+    /// * `Ok(Language)` if the code is valid and the language is enabled
+    /// * `Err` if the code is not found or the language is disabled
+    ///
+    /// # Example
+    /// ```ignore
+    /// let spanish = Language::from_code("es")?;
+    /// ```
+    pub fn from_code(code: &str) -> Result<Language> {
+        let registry = LanguageRegistry::get();
+
+        match registry.get_by_code(code) {
+            Some(config) if config.enabled => Ok(Language {
+                code: config.code, // Use the static str from the registry
+            }),
+            Some(_) => bail!("Language '{}' is not enabled", code),
+            None => bail!("Unknown language code: '{}'", code),
+        }
+    }
+
+    /// Get the canonical (source) language.
+    ///
+    /// This is the language that all summaries are originally generated in,
+    /// and from which all translations are derived.
+    ///
+    /// # Returns
+    /// The canonical Language (typically English).
+    pub fn canonical() -> Language {
+        let config = LanguageRegistry::get().canonical();
+        Language { code: config.code }
+    }
+
+    /// Get the ISO 639-1 language code.
+    ///
+    /// # Returns
+    /// The language code as a static string (e.g., "en", "es").
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    /// Get the full language configuration from the registry.
+    ///
+    /// # Returns
+    /// A reference to the `LanguageConfig` for this language.
+    ///
+    /// # Panics
+    /// Panics if the language code is not found in the registry. This should
+    /// never happen if the Language was constructed properly (via `from_code`
+    /// or constants).
+    pub fn config(&self) -> &'static LanguageConfig {
+        LanguageRegistry::get()
+            .get_by_code(self.code)
+            .expect("Language code should always be valid")
+    }
+
+    /// Get the English name of the language.
+    ///
+    /// # Returns
+    /// The language name in English (e.g., "English", "Spanish").
+    pub fn name(&self) -> &'static str {
+        self.config().name
+    }
+
+    /// Get the native name of the language.
+    ///
+    /// # Returns
+    /// The language name in its native form (e.g., "English", "Español").
+    pub fn native_name(&self) -> &'static str {
+        self.config().native_name
+    }
+
+    /// Check if this is the canonical language.
+    ///
+    /// # Returns
+    /// `true` if this is the source language, `false` if it's a translation target.
+    pub fn is_canonical(&self) -> bool {
+        self.config().is_canonical
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== Constant Tests ====================
+
+    #[test]
+    fn test_english_constant() {
+        let english = Language::ENGLISH;
+        assert_eq!(english.code(), "en");
+        assert_eq!(english.name(), "English");
+        assert!(english.is_canonical());
+    }
+
+    #[test]
+    fn test_spanish_constant() {
+        let spanish = Language::SPANISH;
+        assert_eq!(spanish.code(), "es");
+        assert_eq!(spanish.name(), "Spanish");
+        assert!(!spanish.is_canonical());
+    }
+
+    // ==================== from_code Tests ====================
+
+    #[test]
+    fn test_from_code_english() {
+        let language = Language::from_code("en").expect("Should succeed");
+        assert_eq!(language.code(), "en");
+        assert_eq!(language.name(), "English");
+    }
+
+    #[test]
+    fn test_from_code_spanish() {
+        let language = Language::from_code("es").expect("Should succeed");
+        assert_eq!(language.code(), "es");
+        assert_eq!(language.name(), "Spanish");
+    }
+
+    #[test]
+    fn test_from_code_invalid() {
+        let result = Language::from_code("fr");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown"));
+    }
+
+    #[test]
+    fn test_from_code_empty() {
+        let result = Language::from_code("");
+        assert!(result.is_err());
+    }
+
+    // ==================== canonical Tests ====================
+
+    #[test]
+    fn test_canonical_returns_english() {
+        let canonical = Language::canonical();
+        assert_eq!(canonical.code(), "en");
+        assert!(canonical.is_canonical());
+    }
+
+    // ==================== Trait Tests ====================
+
+    #[test]
+    fn test_language_equality() {
+        let lang1 = Language::ENGLISH;
+        let lang2 = Language::from_code("en").unwrap();
+        assert_eq!(lang1, lang2);
+    }
+
+    #[test]
+    fn test_language_inequality() {
+        let english = Language::ENGLISH;
+        let spanish = Language::SPANISH;
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn test_language_clone() {
+        let lang = Language::SPANISH;
+        let cloned = lang;
+        assert_eq!(lang, cloned);
+    }
+
+    #[test]
+    fn test_language_copy() {
+        let lang1 = Language::ENGLISH;
+        let lang2 = lang1; // Copy
+        assert_eq!(lang1, lang2); // Both still valid
+    }
+
+    #[test]
+    fn test_language_debug() {
+        let lang = Language::SPANISH;
+        let debug = format!("{:?}", lang);
+        assert!(debug.contains("es"));
+    }
+
+    // ==================== Config Access Tests ====================
+
+    #[test]
+    fn test_config_access() {
+        let lang = Language::SPANISH;
+        let config = lang.config();
+        assert_eq!(config.code, "es");
+        assert_eq!(config.name, "Spanish");
+        assert_eq!(config.native_name, "Español");
+    }
+
+    #[test]
+    fn test_native_name() {
+        let english = Language::ENGLISH;
+        let spanish = Language::SPANISH;
+        assert_eq!(english.native_name(), "English");
+        assert_eq!(spanish.native_name(), "Español");
+    }
+
+    // ==================== Backward Compatibility Tests ====================
+
+    #[test]
+    fn test_backward_compat_english() {
+        // Old code: Language::English.code()
+        // New code: Language::ENGLISH.code()
+        assert_eq!(Language::ENGLISH.code(), "en");
+    }
+
+    #[test]
+    fn test_backward_compat_spanish() {
+        // Old code: Language::Spanish.code()
+        // New code: Language::SPANISH.code()
+        assert_eq!(Language::SPANISH.code(), "es");
+    }
+
+    #[test]
+    fn test_backward_compat_from_code() {
+        // Old code: Language::from_code("en")
+        // New code: Still works the same
+        let result = Language::from_code("en");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().code(), "en");
+    }
+
+    #[test]
+    fn test_backward_compat_is_canonical() {
+        // Old code: Language::English.is_canonical()
+        // New code: Language::ENGLISH.is_canonical()
+        assert!(Language::ENGLISH.is_canonical());
+        assert!(!Language::SPANISH.is_canonical());
+    }
+}

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -1,0 +1,34 @@
+//! Internationalization (i18n) module for multi-language support.
+//!
+//! This module provides a centralized, extensible architecture for managing
+//! multiple languages. All language-related logic, localized strings, and
+//! translation infrastructure is contained here.
+//!
+//! # Architecture
+//!
+//! - `registry`: Single source of truth for all supported languages and their metadata
+//! - `language`: Type-safe Language type that replaces hardcoded enums
+//! - `strings`: Centralized localized strings (Phase 3)
+//! - `validator`: Translation quality validation (Phase 4)
+//! - `metrics`: Translation observability and metrics (Phase 4)
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use crate::i18n::{Language, LanguageRegistry};
+//!
+//! // Get canonical language (English)
+//! let canonical = Language::canonical();
+//!
+//! // Create language from code
+//! let spanish = Language::from_code("es")?;
+//!
+//! // List all enabled languages
+//! let languages = LanguageRegistry::get().list_enabled();
+//! ```
+
+mod language;
+mod registry;
+
+pub use language::Language;
+pub use registry::{LanguageConfig, LanguageRegistry};

--- a/src/i18n/registry.rs
+++ b/src/i18n/registry.rs
@@ -1,0 +1,253 @@
+//! Language registry: Single source of truth for all supported languages.
+//!
+//! This module provides a centralized registry of all languages supported by the
+//! application. It uses a singleton pattern with `OnceLock` to ensure thread-safe
+//! initialization and access.
+
+use std::sync::OnceLock;
+
+/// Configuration for a supported language.
+///
+/// Contains all metadata and settings for a specific language, including
+/// its code, names, enabled status, and whether it's the canonical language.
+#[derive(Debug, Clone)]
+pub struct LanguageConfig {
+    /// ISO 639-1 language code (e.g., "en", "es", "fr")
+    pub code: &'static str,
+
+    /// English name of the language (e.g., "English", "Spanish", "French")
+    pub name: &'static str,
+
+    /// Native name of the language (e.g., "English", "Español", "Français")
+    pub native_name: &'static str,
+
+    /// Whether this is the canonical/source language (only one should be true)
+    pub is_canonical: bool,
+
+    /// Whether this language is enabled for use
+    pub enabled: bool,
+}
+
+/// Global language registry singleton.
+///
+/// This registry contains all supported languages and provides methods to query
+/// and access them. It's initialized once on first access and remains immutable
+/// thereafter.
+pub struct LanguageRegistry {
+    languages: Vec<LanguageConfig>,
+}
+
+/// Global registry instance (initialized lazily)
+static REGISTRY: OnceLock<LanguageRegistry> = OnceLock::new();
+
+impl LanguageRegistry {
+    /// Get the global language registry instance.
+    ///
+    /// This method initializes the registry on first call and returns a reference
+    /// to the singleton instance on subsequent calls.
+    pub fn get() -> &'static LanguageRegistry {
+        REGISTRY.get_or_init(|| LanguageRegistry {
+            languages: default_languages(),
+        })
+    }
+
+    /// Get a language configuration by its code.
+    ///
+    /// # Arguments
+    /// * `code` - The ISO 639-1 language code (e.g., "en", "es")
+    ///
+    /// # Returns
+    /// * `Some(&LanguageConfig)` if the language exists
+    /// * `None` if the language is not found
+    pub fn get_by_code(&self, code: &str) -> Option<&LanguageConfig> {
+        self.languages.iter().find(|lang| lang.code == code)
+    }
+
+    /// Get all enabled languages.
+    ///
+    /// # Returns
+    /// A vector of references to all language configurations where `enabled` is true.
+    pub fn list_enabled(&self) -> Vec<&LanguageConfig> {
+        self.languages.iter().filter(|lang| lang.enabled).collect()
+    }
+
+    /// Get all languages (including disabled ones).
+    ///
+    /// # Returns
+    /// A vector of references to all language configurations.
+    pub fn list_all(&self) -> Vec<&LanguageConfig> {
+        self.languages.iter().collect()
+    }
+
+    /// Get the canonical language configuration.
+    ///
+    /// The canonical language is the source language for all translations
+    /// (typically English). There should be exactly one canonical language.
+    ///
+    /// # Returns
+    /// A reference to the canonical language configuration.
+    ///
+    /// # Panics
+    /// Panics if no canonical language is found or if multiple canonical
+    /// languages are defined (this indicates a configuration error).
+    pub fn canonical(&self) -> &LanguageConfig {
+        let canonical_langs: Vec<_> = self
+            .languages
+            .iter()
+            .filter(|lang| lang.is_canonical)
+            .collect();
+
+        match canonical_langs.len() {
+            0 => panic!("No canonical language found in registry"),
+            1 => canonical_langs[0],
+            _ => panic!("Multiple canonical languages found in registry"),
+        }
+    }
+
+    /// Check if a language code is supported and enabled.
+    ///
+    /// # Arguments
+    /// * `code` - The ISO 639-1 language code to check
+    ///
+    /// # Returns
+    /// `true` if the language exists and is enabled, `false` otherwise.
+    pub fn is_enabled(&self, code: &str) -> bool {
+        self.get_by_code(code)
+            .map(|lang| lang.enabled)
+            .unwrap_or(false)
+    }
+}
+
+/// Default language configurations.
+///
+/// This function returns the initial set of supported languages.
+/// Currently supports English (canonical) and Spanish.
+fn default_languages() -> Vec<LanguageConfig> {
+    vec![
+        LanguageConfig {
+            code: "en",
+            name: "English",
+            native_name: "English",
+            is_canonical: true,
+            enabled: true,
+        },
+        LanguageConfig {
+            code: "es",
+            name: "Spanish",
+            native_name: "Español",
+            is_canonical: false,
+            enabled: true,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_get_returns_singleton() {
+        let registry1 = LanguageRegistry::get();
+        let registry2 = LanguageRegistry::get();
+
+        // Should return the same instance (same memory address)
+        assert!(std::ptr::eq(registry1, registry2));
+    }
+
+    #[test]
+    fn test_get_by_code_english() {
+        let registry = LanguageRegistry::get();
+        let config = registry.get_by_code("en");
+
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert_eq!(config.code, "en");
+        assert_eq!(config.name, "English");
+        assert_eq!(config.native_name, "English");
+        assert!(config.is_canonical);
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn test_get_by_code_spanish() {
+        let registry = LanguageRegistry::get();
+        let config = registry.get_by_code("es");
+
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert_eq!(config.code, "es");
+        assert_eq!(config.name, "Spanish");
+        assert_eq!(config.native_name, "Español");
+        assert!(!config.is_canonical);
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn test_get_by_code_nonexistent() {
+        let registry = LanguageRegistry::get();
+        let config = registry.get_by_code("fr");
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_list_enabled_contains_english_and_spanish() {
+        let registry = LanguageRegistry::get();
+        let enabled = registry.list_enabled();
+
+        assert_eq!(enabled.len(), 2);
+        assert!(enabled.iter().any(|lang| lang.code == "en"));
+        assert!(enabled.iter().any(|lang| lang.code == "es"));
+    }
+
+    #[test]
+    fn test_list_all_contains_english_and_spanish() {
+        let registry = LanguageRegistry::get();
+        let all = registry.list_all();
+
+        assert_eq!(all.len(), 2);
+        assert!(all.iter().any(|lang| lang.code == "en"));
+        assert!(all.iter().any(|lang| lang.code == "es"));
+    }
+
+    #[test]
+    fn test_canonical_returns_english() {
+        let registry = LanguageRegistry::get();
+        let canonical = registry.canonical();
+
+        assert_eq!(canonical.code, "en");
+        assert!(canonical.is_canonical);
+    }
+
+    #[test]
+    fn test_is_enabled_english() {
+        let registry = LanguageRegistry::get();
+        assert!(registry.is_enabled("en"));
+    }
+
+    #[test]
+    fn test_is_enabled_spanish() {
+        let registry = LanguageRegistry::get();
+        assert!(registry.is_enabled("es"));
+    }
+
+    #[test]
+    fn test_is_enabled_nonexistent() {
+        let registry = LanguageRegistry::get();
+        assert!(!registry.is_enabled("fr"));
+    }
+
+    #[test]
+    fn test_language_config_clone() {
+        let config = LanguageConfig {
+            code: "en",
+            name: "English",
+            native_name: "English",
+            is_canonical: true,
+            enabled: true,
+        };
+
+        let cloned = config.clone();
+        assert_eq!(config.code, cloned.code);
+        assert_eq!(config.name, cloned.name);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod db;
+pub mod i18n;
 pub mod openai;
 pub mod rss;
 pub mod scheduler;

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -442,8 +442,9 @@ pub async fn send_to_subscribers(
     summary: &str,
     summary_id: i64,
 ) -> Result<()> {
+    use crate::i18n::Language;
     use crate::translation::{
-        get_summary_header, get_translation_failure_notice, translate_summary, Language,
+        get_summary_header, get_translation_failure_notice, translate_summary,
     };
 
     let subscribers = db.list_subscribers().await?;
@@ -471,7 +472,7 @@ pub async fn send_to_subscribers(
 
     for subscriber in subscribers {
         let lang_code = subscriber.language_code.clone();
-        let language = Language::from_code(&lang_code).unwrap_or(Language::English);
+        let language = Language::from_code(&lang_code).unwrap_or(Language::ENGLISH);
 
         // Get or create translation for this language
         let content = if let Some(cached) = translation_cache.get(&lang_code) {


### PR DESCRIPTION
Transform hardcoded two-language system into extensible, registry-based architecture. This is backward compatible and maintains all existing functionality while enabling easy addition of new languages.

Changes:
- Create src/i18n/ module with Language registry and flexible Language type
- Replace hardcoded Language enum with registry-validated struct
- Add backward-compatible constants (Language::ENGLISH, Language::SPANISH)
- Update translation.rs and telegram.rs to use new infrastructure
- Add database migration for flexible language code constraints
- Add 29 unit tests for i18n module (all passing)
- Maintain 100% backward compatibility (all 56 existing tests pass)

Benefits:
- Adding new language takes ~5 minutes (single struct definition)
- Single source of truth for language metadata in registry
- Type-safe language validation against registry
- Database constraint now accepts any ISO 639 code (2-5 letters)

Phase 3-5 pending: Centralized strings, validation, metrics, E2E tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded language support with flexible language code format—now accepting 2–5 lowercase letter codes instead of hardcoded English and Spanish.
  * Introduced a language registry system providing centralized language management and validation.

* **Database Changes**
  * Updated subscriber language code validation to enforce the new flexible language code constraint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->