### PR TITLE
fix: /start uses subscriber's language + webhook returns OK on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,8 +138,11 @@ async fn webhook_handler(
     match telegram::handle_webhook(&state.config, &state.db, update).await {
         Ok(_) => StatusCode::OK,
         Err(e) => {
+            // Log the error but return OK to prevent Telegram from retrying.
+            // Returning non-200 causes Telegram to retry the same update indefinitely,
+            // which can cause the bot to get "stuck" on a failing update.
             warn!("Webhook handler error: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            StatusCode::OK
         }
     }
 }


### PR DESCRIPTION
1. The /start command now checks if the user is already subscribed and responds in their preferred language (was always using English)

2. Webhook handler now returns StatusCode::OK even on errors to prevent Telegram from retrying the same update indefinitely, which was causing the bot to get "stuck" on failing updates

Added test: test_start_response_uses_subscriber_language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Welcome messages now automatically display in users' preferred language, providing a personalized greeting experience for multilingual subscribers.

* **Bug Fixes**
  * Improved webhook request processing and error handling to enhance service reliability and ensure consistent message delivery.

* **Tests**
  * Added comprehensive test coverage for language preference functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->