### PR TITLE
fix: improve translation quality for Spanish summaries

### DIFF
--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -36,5 +36,7 @@ mod validator;
 pub use language::Language;
 pub use metrics::{MetricsReport, TranslationMetrics};
 pub use registry::{LanguageConfig, LanguageRegistry};
-pub use strings::LanguageStrings;
-pub use validator::{TranslationValidator, ValidationReport};
+pub use strings::{
+    LanguageStrings, SectionHeaders, ENGLISH_SECTION_HEADERS, SPANISH_SECTION_HEADERS,
+};
+pub use validator::{TranslationValidator, ValidationReport, ENGLISH_HEADERS};

--- a/src/i18n/strings.rs
+++ b/src/i18n/strings.rs
@@ -1,3 +1,47 @@
+/// Section header translations for AI-generated summaries.
+///
+/// These correspond to the headers used in src/openai.rs build_system_prompt().
+/// The English values are canonical and used as-is; other languages get translated.
+#[derive(Debug, Clone)]
+pub struct SectionHeaders {
+    /// "🧠 Top takeaways" section
+    pub top_takeaways: &'static str,
+    /// "🚀 Releases" section
+    pub releases: &'static str,
+    /// "🔬 Research" section
+    pub research: &'static str,
+    /// "🧰 Tools and Tutorials" section
+    pub tools_tutorials: &'static str,
+    /// "🏢 Companies and Deals" section
+    pub companies_deals: &'static str,
+    /// "⚖️ Policy and Safety" section
+    pub policy_safety: &'static str,
+    /// "💬 Debate and Opinions" section
+    pub debate_opinions: &'static str,
+}
+
+/// English section headers (canonical - used in summarization prompt)
+pub const ENGLISH_SECTION_HEADERS: SectionHeaders = SectionHeaders {
+    top_takeaways: "🧠 Top takeaways",
+    releases: "🚀 Releases",
+    research: "🔬 Research",
+    tools_tutorials: "🧰 Tools and Tutorials",
+    companies_deals: "🏢 Companies and Deals",
+    policy_safety: "⚖️ Policy and Safety",
+    debate_opinions: "💬 Debate and Opinions",
+};
+
+/// Spanish section headers (translations)
+pub const SPANISH_SECTION_HEADERS: SectionHeaders = SectionHeaders {
+    top_takeaways: "🧠 Conclusiones principales",
+    releases: "🚀 Lanzamientos",
+    research: "🔬 Investigación",
+    tools_tutorials: "🧰 Herramientas y tutoriales",
+    companies_deals: "🏢 Empresas y acuerdos",
+    policy_safety: "⚖️ Política y seguridad",
+    debate_opinions: "💬 Debate y opiniones",
+};
+
 /// All localized user-facing strings for a language
 ///
 /// Strings are stored in their raw, unescaped form. When displaying in Telegram,
@@ -11,6 +55,9 @@ pub struct LanguageStrings {
     /// Notice shown when translation fails and falling back to English
     /// Empty string means no notice is needed (e.g., for English itself)
     pub translation_failure_notice: &'static str,
+
+    /// Section headers for AI-generated summaries
+    pub section_headers: SectionHeaders,
 
     // ==================== Welcome/Help Messages ====================
     /// Welcome message shown to admin users
@@ -97,6 +144,7 @@ pub const ENGLISH_STRINGS: LanguageStrings = LanguageStrings {
     // Summary headers
     summary_header: "Twitter Summary",
     translation_failure_notice: "", // No notice needed for English
+    section_headers: ENGLISH_SECTION_HEADERS,
 
     // Welcome messages
     welcome_admin: "👋 Welcome to Twitter News Summary Bot\\!\n\n\
@@ -164,6 +212,7 @@ pub const SPANISH_STRINGS: LanguageStrings = LanguageStrings {
     // Summary headers
     summary_header: "Resumen de Twitter",
     translation_failure_notice: "\\[Nota: La traducción no está disponible\\. Enviando en inglés\\.\\]\n\n",
+    section_headers: SPANISH_SECTION_HEADERS,
 
     // Welcome messages
     welcome_admin: "👋 ¡Bienvenido al Bot de Resumen de Noticias de Twitter\\!\n\n\
@@ -879,5 +928,115 @@ mod tests {
                 errors.join("\n")
             );
         }
+    }
+
+    // ==================== Section Headers Tests ====================
+
+    #[test]
+    fn test_english_section_headers_have_emojis() {
+        assert!(ENGLISH_SECTION_HEADERS.top_takeaways.starts_with("🧠"));
+        assert!(ENGLISH_SECTION_HEADERS.releases.starts_with("🚀"));
+        assert!(ENGLISH_SECTION_HEADERS.research.starts_with("🔬"));
+        assert!(ENGLISH_SECTION_HEADERS.tools_tutorials.starts_with("🧰"));
+        assert!(ENGLISH_SECTION_HEADERS.companies_deals.starts_with("🏢"));
+        assert!(ENGLISH_SECTION_HEADERS.policy_safety.starts_with("⚖️"));
+        assert!(ENGLISH_SECTION_HEADERS.debate_opinions.starts_with("💬"));
+    }
+
+    #[test]
+    fn test_spanish_section_headers_have_same_emojis() {
+        // Spanish headers must have the same emojis as English
+        assert!(SPANISH_SECTION_HEADERS.top_takeaways.starts_with("🧠"));
+        assert!(SPANISH_SECTION_HEADERS.releases.starts_with("🚀"));
+        assert!(SPANISH_SECTION_HEADERS.research.starts_with("🔬"));
+        assert!(SPANISH_SECTION_HEADERS.tools_tutorials.starts_with("🧰"));
+        assert!(SPANISH_SECTION_HEADERS.companies_deals.starts_with("🏢"));
+        assert!(SPANISH_SECTION_HEADERS.policy_safety.starts_with("⚖️"));
+        assert!(SPANISH_SECTION_HEADERS.debate_opinions.starts_with("💬"));
+    }
+
+    #[test]
+    fn test_spanish_section_headers_are_translated() {
+        // Spanish headers must be different from English (actually translated)
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.top_takeaways,
+            ENGLISH_SECTION_HEADERS.top_takeaways
+        );
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.releases,
+            ENGLISH_SECTION_HEADERS.releases
+        );
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.research,
+            ENGLISH_SECTION_HEADERS.research
+        );
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.tools_tutorials,
+            ENGLISH_SECTION_HEADERS.tools_tutorials
+        );
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.companies_deals,
+            ENGLISH_SECTION_HEADERS.companies_deals
+        );
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.policy_safety,
+            ENGLISH_SECTION_HEADERS.policy_safety
+        );
+        assert_ne!(
+            SPANISH_SECTION_HEADERS.debate_opinions,
+            ENGLISH_SECTION_HEADERS.debate_opinions
+        );
+    }
+
+    #[test]
+    fn test_spanish_section_headers_contain_spanish_words() {
+        // Verify Spanish translations contain Spanish words
+        assert!(SPANISH_SECTION_HEADERS
+            .top_takeaways
+            .contains("Conclusiones"));
+        assert!(SPANISH_SECTION_HEADERS.releases.contains("Lanzamientos"));
+        assert!(SPANISH_SECTION_HEADERS.research.contains("Investigación"));
+        assert!(SPANISH_SECTION_HEADERS
+            .tools_tutorials
+            .contains("Herramientas"));
+        assert!(SPANISH_SECTION_HEADERS.companies_deals.contains("Empresas"));
+        assert!(SPANISH_SECTION_HEADERS.policy_safety.contains("Política"));
+        assert!(SPANISH_SECTION_HEADERS.debate_opinions.contains("Debate"));
+    }
+
+    #[test]
+    fn test_language_strings_include_section_headers() {
+        // Verify that LanguageStrings correctly includes section headers
+        assert_eq!(
+            ENGLISH_STRINGS.section_headers.top_takeaways,
+            ENGLISH_SECTION_HEADERS.top_takeaways
+        );
+        assert_eq!(
+            SPANISH_STRINGS.section_headers.top_takeaways,
+            SPANISH_SECTION_HEADERS.top_takeaways
+        );
+    }
+
+    #[test]
+    fn test_all_english_section_headers_list() {
+        // Verify we can get all English headers as an array (useful for validation)
+        let headers = [
+            ENGLISH_SECTION_HEADERS.top_takeaways,
+            ENGLISH_SECTION_HEADERS.releases,
+            ENGLISH_SECTION_HEADERS.research,
+            ENGLISH_SECTION_HEADERS.tools_tutorials,
+            ENGLISH_SECTION_HEADERS.companies_deals,
+            ENGLISH_SECTION_HEADERS.policy_safety,
+            ENGLISH_SECTION_HEADERS.debate_opinions,
+        ];
+
+        // All should be non-empty and unique
+        for header in &headers {
+            assert!(!header.is_empty());
+        }
+
+        // Check all are unique
+        let unique: std::collections::HashSet<_> = headers.iter().collect();
+        assert_eq!(unique.len(), headers.len(), "All headers should be unique");
     }
 }

--- a/src/i18n/validator.rs
+++ b/src/i18n/validator.rs
@@ -4,6 +4,8 @@
 //! important elements are preserved during translation (e.g., @handles,
 //! #hashtags, URLs, etc.).
 
+use super::strings::ENGLISH_SECTION_HEADERS;
+use super::Language;
 use regex::Regex;
 use std::sync::OnceLock;
 
@@ -58,6 +60,18 @@ static CASHTAG_REGEX: OnceLock<Regex> = OnceLock::new();
 static URL_REGEX: OnceLock<Regex> = OnceLock::new();
 static MARKDOWN_LINK_REGEX: OnceLock<Regex> = OnceLock::new();
 
+/// List of all English section headers used in summaries.
+/// These should NOT appear in translated content for non-English targets.
+pub const ENGLISH_HEADERS: [&str; 7] = [
+    ENGLISH_SECTION_HEADERS.top_takeaways,
+    ENGLISH_SECTION_HEADERS.releases,
+    ENGLISH_SECTION_HEADERS.research,
+    ENGLISH_SECTION_HEADERS.tools_tutorials,
+    ENGLISH_SECTION_HEADERS.companies_deals,
+    ENGLISH_SECTION_HEADERS.policy_safety,
+    ENGLISH_SECTION_HEADERS.debate_opinions,
+];
+
 impl TranslationValidator {
     /// Validate that a translation preserves important elements from the original.
     ///
@@ -67,14 +81,20 @@ impl TranslationValidator {
     /// - $cashtags are preserved
     /// - URLs are preserved
     /// - Markdown links are preserved
+    /// - Section headers are translated (for non-English targets)
     ///
     /// # Arguments
     /// * `original` - The original text (before translation)
     /// * `translated` - The translated text
+    /// * `target_language` - The target language of the translation
     ///
     /// # Returns
     /// A `ValidationReport` containing any errors or warnings found.
-    pub fn validate(original: &str, translated: &str) -> ValidationReport {
+    pub fn validate(
+        original: &str,
+        translated: &str,
+        target_language: Language,
+    ) -> ValidationReport {
         let mut report = ValidationReport::new();
 
         // Check @handles
@@ -129,7 +149,30 @@ impl TranslationValidator {
             ));
         }
 
+        // Check for untranslated section headers (only for non-English targets)
+        if !target_language.is_canonical() {
+            let untranslated = Self::find_untranslated_headers(translated);
+            for header in untranslated {
+                report.errors.push(format!(
+                    "Untranslated section header found: '{}' should be translated to {}",
+                    header,
+                    target_language.name()
+                ));
+            }
+        }
+
         report
+    }
+
+    /// Find any English section headers that appear in the translated text.
+    ///
+    /// Returns a list of headers that were NOT translated.
+    pub fn find_untranslated_headers(translated: &str) -> Vec<&'static str> {
+        ENGLISH_HEADERS
+            .iter()
+            .filter(|header| translated.contains(*header))
+            .copied()
+            .collect()
     }
 
     /// Extract all @handles from text
@@ -324,7 +367,7 @@ mod tests {
         let original = "Check out @elonmusk talking about #AI at https://example.com";
         let translated = "Mira a @elonmusk hablando de #AI en https://example.com";
 
-        let report = TranslationValidator::validate(original, translated);
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
         assert!(report.is_clean());
     }
 
@@ -333,7 +376,7 @@ mod tests {
         let original = "Follow @elonmusk for updates";
         let translated = "Sigue a elonmusk para actualizaciones";
 
-        let report = TranslationValidator::validate(original, translated);
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
         assert!(report.has_warnings());
         assert!(report.warnings[0].contains("Handle mismatch"));
     }
@@ -343,7 +386,7 @@ mod tests {
         let original = "This is about #AI technology";
         let translated = "Esto es sobre tecnología AI";
 
-        let report = TranslationValidator::validate(original, translated);
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
         assert!(report.has_warnings());
         assert!(report.warnings[0].contains("Hashtag mismatch"));
     }
@@ -353,7 +396,7 @@ mod tests {
         let original = "Read more at https://example.com";
         let translated = "Lee más aquí";
 
-        let report = TranslationValidator::validate(original, translated);
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
         assert!(report.has_warnings());
         assert!(report.warnings[0].contains("URL mismatch"));
     }
@@ -363,7 +406,7 @@ mod tests {
         let original = "Stock price of $TSLA is up";
         let translated = "El precio de TSLA está subiendo";
 
-        let report = TranslationValidator::validate(original, translated);
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
         assert!(report.has_warnings());
         assert!(report.warnings[0].contains("Cashtag mismatch"));
     }
@@ -375,8 +418,95 @@ mod tests {
         let translated =
             "@sama habla de #AI y $NVDA en https://example.com con [enlace](https://test.com)";
 
-        let report = TranslationValidator::validate(original, translated);
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
         assert!(report.is_clean());
+    }
+
+    // ==================== Untranslated Header Detection Tests ====================
+
+    #[test]
+    fn test_validate_detects_untranslated_headers() {
+        let original = "🧠 Top takeaways\n- *Item* — text [link](url)";
+        // Translation leaves the header in English - this is a validation ERROR
+        let translated = "🧠 Top takeaways\n- *Elemento* — texto [enlace](url)";
+
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
+        assert!(report.has_errors());
+        assert!(report.errors[0].contains("Untranslated section header"));
+        assert!(report.errors[0].contains("Top takeaways"));
+    }
+
+    #[test]
+    fn test_validate_accepts_translated_headers() {
+        let original = "🧠 Top takeaways\n- *Item* — text [link](url)";
+        // Properly translated - header is in Spanish
+        let translated = "🧠 Conclusiones principales\n- *Elemento* — texto [enlace](url)";
+
+        let report = TranslationValidator::validate(original, translated, Language::SPANISH);
+        // Should not have errors about untranslated headers
+        assert!(
+            !report.has_errors(),
+            "Should not have errors for properly translated headers"
+        );
+    }
+
+    #[test]
+    fn test_validate_english_target_ignores_english_headers() {
+        let original = "🧠 Top takeaways\n- *Item* — text";
+        let translated = "🧠 Top takeaways\n- *Item* — text"; // Same content
+
+        // For English target, English headers are expected - no error
+        let report = TranslationValidator::validate(original, translated, Language::ENGLISH);
+        assert!(!report.has_errors());
+    }
+
+    #[test]
+    fn test_find_untranslated_headers_single() {
+        let text = "🧠 Top takeaways\n- *Item* — text";
+        let untranslated = TranslationValidator::find_untranslated_headers(text);
+        assert_eq!(untranslated.len(), 1);
+        assert!(untranslated.contains(&"🧠 Top takeaways"));
+    }
+
+    #[test]
+    fn test_find_untranslated_headers_multiple() {
+        let text = "🧠 Top takeaways\n- item\n\n🚀 Releases\n- item\n\n🔬 Research\n- item";
+        let untranslated = TranslationValidator::find_untranslated_headers(text);
+        assert_eq!(untranslated.len(), 3);
+        assert!(untranslated.contains(&"🧠 Top takeaways"));
+        assert!(untranslated.contains(&"🚀 Releases"));
+        assert!(untranslated.contains(&"🔬 Research"));
+    }
+
+    #[test]
+    fn test_find_untranslated_headers_none_when_translated() {
+        // All headers are in Spanish - should find none
+        let text = "🧠 Conclusiones principales\n- elemento\n\n🚀 Lanzamientos\n- elemento";
+        let untranslated = TranslationValidator::find_untranslated_headers(text);
+        assert!(untranslated.is_empty());
+    }
+
+    #[test]
+    fn test_find_untranslated_headers_partial_translation() {
+        // Some headers translated, some not
+        let text = "🧠 Conclusiones principales\n- item\n\n🚀 Releases\n- item"; // Releases NOT translated
+        let untranslated = TranslationValidator::find_untranslated_headers(text);
+        assert_eq!(untranslated.len(), 1);
+        assert!(untranslated.contains(&"🚀 Releases"));
+        assert!(!untranslated.contains(&"🧠 Top takeaways")); // This was translated
+    }
+
+    #[test]
+    fn test_all_english_headers_are_covered() {
+        // Verify ENGLISH_HEADERS contains all the expected headers
+        assert_eq!(ENGLISH_HEADERS.len(), 7);
+        assert!(ENGLISH_HEADERS.contains(&"🧠 Top takeaways"));
+        assert!(ENGLISH_HEADERS.contains(&"🚀 Releases"));
+        assert!(ENGLISH_HEADERS.contains(&"🔬 Research"));
+        assert!(ENGLISH_HEADERS.contains(&"🧰 Tools and Tutorials"));
+        assert!(ENGLISH_HEADERS.contains(&"🏢 Companies and Deals"));
+        assert!(ENGLISH_HEADERS.contains(&"⚖️ Policy and Safety"));
+        assert!(ENGLISH_HEADERS.contains(&"💬 Debate and Opinions"));
     }
 
     #[test]


### PR DESCRIPTION
- Add explicit section header mappings (SectionHeaders struct) with translations for all 7 summary sections
- Enhance translation prompt with mandatory header mapping table and concrete examples of correct vs incorrect translations
- Add validation to detect untranslated English headers in translations
- Make validation errors block bad translations (falls back to English)
- Add comprehensive tests for header translation validation

Fixes issue where Spanish translations had mixed English/Spanish content including untranslated section headers, bullet titles, and link labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced language-aware translation validation that considers the target language when validating translated content
  * Added localized section headers for AI-generated summaries in English and Spanish

* **Tests**
  * Expanded test coverage for translation validation, header detection, and language-specific prompt generation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->