### PR TITLE
fix: emphasize link label translation in Spanish prompt

### DIFF
--- a/src/translation.rs
+++ b/src/translation.rs
@@ -177,7 +177,12 @@ The link label in [brackets](url) MUST be translated to {target_name}.
 ## KEEP in original English:
 - Any quoted tweet text (text inside quotation marks)
 - Code snippets or technical identifiers
-- Acronyms (AI, ML, LLM, GPU, etc.)
+- Acronyms that are part of brand names (OpenAI, DeepMind, etc.)
+- Technical acronyms without common Spanish equivalents (GPU, CPU, LLM, API, etc.)
+
+## DO translate these acronyms:
+- "AI" → "IA" (Inteligencia Artificial is standard in Spanish)
+- "ML" → "AA" or "aprendizaje automático" (machine learning)
 
 ## Formatting:
 - Preserve all markdown formatting (bold with *, italic with _, bullets with -)


### PR DESCRIPTION
Add dedicated section with explicit examples showing that link labels like [thdxr on coding agents] must be translated to [thdxr sobre agentes de código]. The LLM was keeping link labels in English despite general instructions to translate them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened translation guidance for non-English targets (Spanish): section headers must be translated, link labels are now mandatory to translate, and all bullet parts (title, explanation, link label) require translation.
  * Added explicit examples and preservation rules to keep handles, product names, and URLs unchanged.
  * Tightened validation to enforce these translation rules and improve consistency and completeness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->